### PR TITLE
Highlight flx-ido matches more clearly.

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -222,7 +222,7 @@ names to which it refers are bound."
      (ido-virtual ((,class (:foreground ,comment))))
 
      ;; flx-ido
-     (flx-highlight-face ((,class (:inherit nil :foreground ,orange :weight bold :underline nil))))
+     (flx-highlight-face ((,class (:inherit nil :foreground ,yellow :weight bold :underline nil))))
 
      ;; which-function
      (which-func ((,class (:foreground ,blue :background nil :weight bold))))


### PR DESCRIPTION
This is purely a "taste" pull request, but the highlight of 'flx-ido` matches was very hard to spot with the current color. I made it orange and bold. No hard feelings if you ignore this pull request. It's a matter of taste :)
