### PR TITLE
Change trailing whitespace color

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -275,7 +275,7 @@ names to which it refers are bound."
 
       (header-line (:inherit mode-line :foreground ,purple :background nil))
 
-      (trailing-whitespace (:background ,red :foreground ,yellow))
+      (trailing-whitespace (:background ,selection :foreground ,yellow))
       (whitespace-empty (:foreground ,red :background ,yellow))
       (whitespace-hspace (:background ,contrast-bg :foreground ,comment))
       (whitespace-indentation (:background ,contrast-bg :foreground ,comment))


### PR DESCRIPTION
Using `red` as the color is confusing because the cursor is also red, so
it is hard to tell what is trailing whitespace and what is the cursor.

Here's a screenshot showing what I mean:

![screenshot from 2015-12-10 15-50-10](https://cloud.githubusercontent.com/assets/19060/11731045/e260c106-9f55-11e5-964a-7f8d41102929.png)
