### PR TITLE
Add faces for sx.el

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -767,6 +767,9 @@ names to which it refers are bound."
       (rpm-spec-section-face (:foreground ,yellow))
       (rpm-spec-tag-face (:foreground ,blue))
       (rpm-spec-var-face (:foreground ,red))
+
+      ;; sx
+      (sx-question-mode-content-face (:background ,highlight))
       ))))
 
 (defmacro color-theme-sanityinc-tomorrow--frame-parameter-specs ()


### PR DESCRIPTION
This pull request simply changes the `sx-question-mode-content-face` to be the same as `highlight` it makes `sx.el` look prettier (in my opinion)  across the board as be seen in the following screenshots

Blue:
Before:
![sx-screenshot-before-blue](https://cloud.githubusercontent.com/assets/5892061/14472827/0ad487c0-00c3-11e6-8791-9a0c2ae96fde.jpg)
After:
![sx-screenshot-after-blue](https://cloud.githubusercontent.com/assets/5892061/14472829/0ad83f78-00c3-11e6-9f7a-34a77a4958b5.jpg)

Night:
Before:
![sx-screenshot-before](https://cloud.githubusercontent.com/assets/5892061/14472826/0ad3fbe8-00c3-11e6-99b9-f959361d8c04.jpg)
After:
![sx-screenshot-after](https://cloud.githubusercontent.com/assets/5892061/14472828/0ad67a44-00c3-11e6-9d2e-423f850ce642.jpg)
