### PR TITLE
Fix remaining sx.el faces

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -770,6 +770,9 @@ names to which it refers are bound."
 
       ;; sx
       (sx-question-mode-content-face (:background ,highlight))
+      (sx-question-list-answers (:height 1.0 :inherit sx-question-list-parent :foreground ,green))
+      (sx-question-mode-accepted (:height 1.5 :inherit sx-question-mode-title :foreground ,green))
+      (sx-question-mode-kbd-tag (:height 0.9 :weight semi-bold :box (:line-width 3 :style released-button :color ,contrast-bg)))
       ))))
 
 (defmacro color-theme-sanityinc-tomorrow--frame-parameter-specs ()


### PR DESCRIPTION
Small fixes to faces in sx.el that were not previously edited. This is to make all colors in sx.el consistent. Essentially changing all faces that define their own colors to instead use colors defined in the sanity theme.

`sx-question-mode-content-face` still uses the `highlight` color