### PR TITLE
Add tooltip face

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -169,6 +169,7 @@ names to which it refers are bound."
       (success (:foreground ,green))
       (error (:foreground ,red))
       (warning (:foreground ,orange))
+      (tooltip (:background ,contrast-bg))
 
       ;; Flycheck
       (flycheck-error (:underline (:style wave :color ,red)))

--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -169,7 +169,7 @@ names to which it refers are bound."
       (success (:foreground ,green))
       (error (:foreground ,red))
       (warning (:foreground ,orange))
-      (tooltip (:background ,contrast-bg))
+      (tooltip (:background ,highlight))
 
       ;; Flycheck
       (flycheck-error (:underline (:style wave :color ,red)))


### PR DESCRIPTION
Face for the built-in Emacs tooltip implementation.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25563984/13c22b26-2da9-11e7-90d8-bd06dc196cc9.png)
Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25563985/190fc25a-2da9-11e7-9c47-6b54859b7a04.png)
Day:
![day](https://cloud.githubusercontent.com/assets/85483/25563989/1e8339c4-2da9-11e7-8f20-801909ce141b.png)
Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25563993/2a08b4fe-2da9-11e7-8a09-f673bc70ec1a.png)
Night:
![night](https://cloud.githubusercontent.com/assets/85483/25563994/2f74f8ee-2da9-11e7-8f33-e949758fe9d3.png)
