### PR TITLE
Add avy and ace-window support

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -171,6 +171,17 @@ names to which it refers are bound."
       (warning (:foreground ,orange))
       (tooltip (:background ,highlight))
 
+      ;; ace-window
+      (aw-background-face (:foreground ,contrast-bg))
+      (aw-leading-char-face (:foreground ,background :background ,yellow))
+
+      ;; avy
+      (avy-background-face (:foreground ,contrast-bg))
+      (avy-lead-face (:foreground ,background :background ,yellow))
+      (avy-lead-face-0 (:foreground ,background :background ,blue))
+      (avy-lead-face-1 (:foreground ,background :background ,aqua))
+      (avy-lead-face-2 (:foreground ,background :background ,orange))
+
       ;; Flycheck
       (flycheck-error (:underline (:style wave :color ,red)))
       (flycheck-info (:underline (:style wave :color ,aqua)))


### PR DESCRIPTION
This adds support for [avy](https://github.com/abo-abo/avy) and [ace-window](https://github.com/abo-abo/ace-window). Colors for avy were chosen based on `isearch`.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25578367/58ed9274-2e6e-11e7-92c8-fff9a93f9e59.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25578370/5f50fbba-2e6e-11e7-9440-1ed4156167c7.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/25578373/650fd0bc-2e6e-11e7-8a42-2acb908978ce.png)

Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25578375/6843e6ce-2e6e-11e7-9398-ece505905975.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/25578376/6c8031e8-2e6e-11e7-876b-7357640ab271.png)

Ace-window shares the first match color as well as background with avy:
![ace-window](https://cloud.githubusercontent.com/assets/85483/25578470/33ec6efe-2e6f-11e7-8e06-f90d838acb4b.png)
