### PR TITLE
Add re-builder support

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -459,6 +459,12 @@ names to which it refers are bound."
 
       (regex-tool-matched-face (:foreground nil :background nil :inherit match))
 
+      ;; re-builder
+      (reb-match-0 (:foreground ,background :background ,aqua))
+      (reb-match-1 (:foreground ,background :background ,yellow))
+      (reb-match-2 (:foreground ,background :background ,orange))
+      (reb-match-3 (:foreground ,background :background ,blue))
+
       ;; mark-multiple
       (mm/master-face (:inherit region :foreground nil :background nil))
       (mm/mirror-face (:inherit region :foreground nil :background nil))


### PR DESCRIPTION
Support for the built-in re-builder package, colors taken from `isearch` and `anzu-match` faces.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25770979/018ff59c-3244-11e7-9dfe-fe530d0d65c1.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25770980/0e1d8e3c-3244-11e7-904f-1f42e7a7669a.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/25770982/1377cfa0-3244-11e7-8e9e-acfc6c2ce130.png)

Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25770983/17616658-3244-11e7-8ec6-fdc8092054c2.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/25770985/1c834de0-3244-11e7-81a4-eccd785adb25.png)
