### PR TITLE
Add support for debbugs

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -687,6 +687,14 @@ names to which it refers are bound."
       (emms-playlist-selected-face (:inverse-video t))
       (emms-playlist-track-face (:inherit outline-4))
 
+      ;; debbugs
+      (debbugs-gnu-done (:foreground ,comment))
+      (debbugs-gnu-handled (:foreground ,green))
+      (debbugs-gnu-new (:foreground ,yellow))
+      (debbugs-gnu-pending (:foreground ,orange))
+      (debbugs-gnu-stale (:foreground ,blue))
+      (debbugs-gnu-tagged (:foreground ,yellow))
+
       ;; mu4e
       (mu4e-header-highlight-face (:underline nil :inherit region))
       (mu4e-header-marks-face (:underline nil :foreground ,yellow))


### PR DESCRIPTION
Support for the [debbugs](https://elpa.gnu.org/packages/debbugs.html) package.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25773985/b33c0bda-3287-11e7-8f74-5b3215cab0a2.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25773986/b7286338-3287-11e7-8eb3-23a7bc19e5c5.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/25773987/bb2fa586-3287-11e7-8e60-c14700b82fef.png)

Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25773988/bf16fb18-3287-11e7-958d-b2e5bfa13fd7.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/25773989/c3322f88-3287-11e7-8845-5fc6e73f1326.png)
