### PR TITLE
Add NeoTree support

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -392,6 +392,24 @@ names to which it refers are bound."
       (diredp-symlink (:foreground ,purple))
       (diredp-write-priv (:foreground ,yellow :background nil))
 
+      ;; neotree
+      (neo-banner-face (:foreground ,blue :weight bold))
+      (neo-button-face (:underline t))
+      (neo-dir-link-face (:foreground ,orange))
+      (neo-expand-btn-face (:foreground ,comment))
+      (neo-file-link-face (:foreground ,foreground))
+      (neo-header-face (:foreground ,foreground :background ,highlight))
+      (neo-root-dir-face (:foreground ,blue :weight bold))
+      (neo-vc-added-face (:foreground ,green))
+      (neo-vc-conflict-face (:foreground ,red))
+      (neo-vc-default-face (:foreground ,foreground))
+      (neo-vc-edited-face (:foreground ,purple))
+      (neo-vc-ignored-face (:foreground ,contrast-bg))
+      (neo-vc-missing-face (:foreground ,red))
+      (neo-vc-needs-merge-face (:foreground ,red))
+      (neo-vc-unlocked-changes-face (:foreground ,blue :slant italic))
+      (neo-vc-user-face (:foreground ,red :slant italic))
+
       ;; Magit
       (magit-blame-heading (:background ,highlight :foreground ,orange))
       (magit-blame-date (:foreground ,red))


### PR DESCRIPTION
Support for the [NeoTree](https://github.com/jaypei/emacs-neotree) package.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25779838/d9b79dfe-331f-11e7-847b-34e3d915896e.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25779841/dd83e258-331f-11e7-8b0d-8874030b5ca8.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/25779842/e0ec7860-331f-11e7-8d14-7c2a5a8fb77e.png)

Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25779843/e4df6edc-331f-11e7-8b83-758d1f23813e.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/25779844/e8d8d6ae-331f-11e7-9f9b-ed1ee1d3f1fd.png)
