### PR TITLE
Ruler mode support

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -581,6 +581,18 @@ names to which it refers are bound."
       (highlight-symbol-face (:inherit highlight))
       (highlight-80+ (:background ,contrast-bg))
 
+      ;; ruler-mode
+      (ruler-mode-column-number (:foreground ,foreground :background ,highlight))
+      (ruler-mode-comment-column (:foreground ,comment :background ,highlight))
+      (ruler-mode-current-column (:foreground ,yellow :background ,highlight :weight bold))
+      (ruler-mode-default (:foreground ,comment :background ,highlight))
+      (ruler-mode-fill-column (:foreground ,red :background ,highlight))
+      (ruler-mode-fringes (:foreground ,green :background ,highlight))
+      (ruler-mode-goal-column (:foreground ,red :background ,highlight))
+      (ruler-mode-margins (:foreground ,orange :background ,highlight))
+      (ruler-mode-pad (:foreground ,foreground :background ,contrast-bg))
+      (ruler-mode-tab-stop (:foreground ,blue :background ,highlight))
+
       ;; Hydra
       (hydra-face-blue (:foreground ,blue))
       (hydra-face-teal (:foreground ,aqua))

--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -583,15 +583,15 @@ names to which it refers are bound."
 
       ;; ruler-mode
       (ruler-mode-column-number (:foreground ,foreground :background ,highlight))
-      (ruler-mode-comment-column (:foreground ,comment :background ,highlight))
-      (ruler-mode-current-column (:foreground ,yellow :background ,highlight :weight bold))
+      (ruler-mode-comment-column (:foreground ,comment :background ,contrast-bg))
+      (ruler-mode-current-column (:foreground ,yellow :background ,contrast-bg :weight bold))
       (ruler-mode-default (:foreground ,comment :background ,highlight))
-      (ruler-mode-fill-column (:foreground ,red :background ,highlight))
-      (ruler-mode-fringes (:foreground ,green :background ,highlight))
-      (ruler-mode-goal-column (:foreground ,red :background ,highlight))
-      (ruler-mode-margins (:foreground ,orange :background ,highlight))
+      (ruler-mode-fill-column (:foreground ,red :background ,contrast-bg))
+      (ruler-mode-fringes (:foreground ,green :background ,contrast-bg))
+      (ruler-mode-goal-column (:foreground ,red :background ,contrast-bg))
+      (ruler-mode-margins (:foreground ,orange :background ,contrast-bg))
       (ruler-mode-pad (:foreground ,background :background ,comment))
-      (ruler-mode-tab-stop (:foreground ,blue :background ,highlight))
+      (ruler-mode-tab-stop (:foreground ,blue :background ,contrast-bg))
 
       ;; Hydra
       (hydra-face-blue (:foreground ,blue))

--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -590,7 +590,7 @@ names to which it refers are bound."
       (ruler-mode-fringes (:foreground ,green :background ,highlight))
       (ruler-mode-goal-column (:foreground ,red :background ,highlight))
       (ruler-mode-margins (:foreground ,orange :background ,highlight))
-      (ruler-mode-pad (:foreground ,foreground :background ,contrast-bg))
+      (ruler-mode-pad (:foreground ,background :background ,comment))
       (ruler-mode-tab-stop (:foreground ,blue :background ,highlight))
 
       ;; Hydra


### PR DESCRIPTION
This adds support for the built-in ruler-mode.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25941295/3439e59a-3639-11e7-9234-55e760035055.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25941300/38266304-3639-11e7-9d36-ea94b06ed183.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/25941307/3d60edda-3639-11e7-87a6-dc9ae9e0b5c7.png)

Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25941313/41b58eae-3639-11e7-98af-584499f1628b.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/25941318/45b61708-3639-11e7-9cc4-d0f837315bb7.png)
