### PR TITLE
Support for hi-lock mode

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -576,6 +576,16 @@ names to which it refers are bound."
       (info-user-option-ref-item (:foreground ,red :background ,highlight))
       (info-variable-ref-item (:inherit font-lock-variable-name-face :background ,highlight))
 
+      ;; hi-lock
+      (hi-black-hb (:weight bold :height 1.4))
+      (hi-blue (:foreground ,background :background ,blue))
+      (hi-blue-b (:foreground ,blue :weight bold))
+      (hi-green (:foreground ,background :background ,green))
+      (hi-green-b (:foreground ,green :weight bold))
+      (hi-pink (:foreground ,background :background ,aqua))
+      (hi-red-b (:foreground ,red :weight bold))
+      (hi-yellow (:foreground ,background :background ,yellow))
+
       ;; hl-line-mode
       (hl-sexp-face (:background ,contrast-bg))
       (highlight-symbol-face (:inherit highlight))


### PR DESCRIPTION
Built-in `hi-lock-mode`, made to match theme colors. Last match uses an oversized font by default so I just reduced its size to `1.4`.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/25967729/5c3d3438-368f-11e7-8837-b5d9be903b0d.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/25967733/60773c42-368f-11e7-95e7-07f3196cbba1.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/25967737/64216f20-368f-11e7-8623-42c86bc333f4.png)

Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/25967741/674fd308-368f-11e7-8603-634dfb45a12b.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/25967745/6af578be-368f-11e7-9b4c-8920ef133d3b.png)
