### PR TITLE
Make diff-refine* faces more subtle

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -384,8 +384,8 @@ names to which it refers are bound."
       (diff-header (:foreground ,aqua :background nil))
       (diff-file-header (:foreground ,blue :background nil))
       (diff-hunk-header (:foreground ,purple))
-      (diff-refine-added (:foreground ,background :background ,blue))
-      (diff-refine-removed (:foreground ,background :background ,orange))
+      (diff-refine-added (:foreground ,blue))
+      (diff-refine-removed (:foreground ,orange))
 
       (diff-hl-insert (:background ,green))
       (diff-hl-change (:background ,blue))


### PR DESCRIPTION
As you mentioned earlier no harsh backgrounds.

Before:
![region](https://cloud.githubusercontent.com/assets/85483/26221353/76fd594c-3c16-11e7-859b-47ded9993e7a.png)

After:
![region2](https://cloud.githubusercontent.com/assets/85483/26221515/162d761e-3c17-11e7-8df3-07f4e95738c6.png)
