### PR TITLE
Add Speedbar support

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -471,6 +471,27 @@ names to which it refers are bound."
       (neo-vc-unlocked-changes-face (:foreground ,blue :slant italic))
       (neo-vc-user-face (:foreground ,red :slant italic))
 
+      ;; Speedbar
+      (speedbar-button-face (:foreground ,green))
+      (speedbar-directory-face (:foreground ,orange))
+      (speedbar-file-face (:foreground ,aqua))
+      (speedbar-highlight-face (:inherit highlight))
+      (speedbar-selected-face (:foreground ,red :underline t))
+      (speedbar-separator-face (:foreground ,background :background ,blue :overline ,background))
+      (speedbar-tag-face (:foreground ,yellow))
+      (vhdl-speedbar-architecture-face (:foreground ,blue))
+      (vhdl-speedbar-architecture-selected-face (:foreground ,blue :underline t))
+      (vhdl-speedbar-configuration-face (:foreground ,green))
+      (vhdl-speedbar-configuration-selected-face (:foreground ,green :underline t))
+      (vhdl-speedbar-entity-face (:foreground ,orange))
+      (vhdl-speedbar-entity-selected-face (:foreground ,orange :underline t))
+      (vhdl-speedbar-instantiation-face (:foreground ,yellow))
+      (vhdl-speedbar-instantiation-selected-face (:foreground ,yellow :underline t))
+      (vhdl-speedbar-library-face (:foreground ,purple))
+      (vhdl-speedbar-package-face (:foreground ,aqua))
+      (vhdl-speedbar-package-selected-face (:foreground ,aqua :underline t))
+      (vhdl-speedbar-subprogram-face (:foreground ,green))
+
       ;; Magit
       (magit-bisect-bad (:foreground ,red))
       (magit-bisect-good (:foreground ,green))


### PR DESCRIPTION
This adds Speedbar support, mostly a 1:1 color translation.

Blue:
![blue](https://cloud.githubusercontent.com/assets/85483/26421822/c7e8b828-40c7-11e7-9e7f-677beeffe5f9.png)

Bright:
![bright](https://cloud.githubusercontent.com/assets/85483/26421829/ce157a9c-40c7-11e7-8143-bf5014ef5b25.png)

Day:
![day](https://cloud.githubusercontent.com/assets/85483/26421840/d20362a4-40c7-11e7-8cb8-c6c969ec2242.png)
Eighties:
![eighties](https://cloud.githubusercontent.com/assets/85483/26421853/d9c2ad06-40c7-11e7-8cc1-7e99f6c45596.png)

Night:
![night](https://cloud.githubusercontent.com/assets/85483/26421857/dda7b038-40c7-11e7-8819-24158f2d55d8.png)
