### PR TITLE
Add form-feed support

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -257,6 +257,9 @@ names to which it refers are bound."
       (clojure-special (:foreground ,blue))
       (clojure-java-call (:foreground ,purple))
 
+      ;; form-feed
+      (form-feed-line (:strike-through ,comment))
+
       ;; Rainbow-delimiters
       (rainbow-delimiters-depth-1-face (:foreground ,foreground))
       (rainbow-delimiters-depth-2-face (:foreground ,aqua))


### PR DESCRIPTION
Support for [form-feed](https://github.com/wasamasa/form-feed), the page break line is white by default so I changed it to comment color.