### PR TITLE
Add some subtle contrast to modeline

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -343,7 +343,8 @@ names to which it refers are bound."
       (border-glyph (nil))
       (highlight (:inverse-video nil :background ,highlight))
       (gui-element (:background ,contrast-bg :foreground ,foreground))
-      (mode-line (:foreground ,foreground :background ,contrast-bg :weight normal))
+      (mode-line (:foreground ,foreground :background ,contrast-bg :weight normal
+                              :box (:line-width 1 :color ,contrast-bg)))
       (mode-line-buffer-id (:foreground ,purple :background nil))
       (mode-line-inactive (:inherit mode-line
                                     :foreground ,comment


### PR DESCRIPTION
Modeline border was removed in 38aa7fefc (Apr 10, 2016). This adds
back the border used then for the inactive mode line for both active
and inactive modelines. This adds a subtle border which helps the eye
distinguish the mode line from text while still looking minimal.