### PR TITLE
backgrounds at wanrline, errline may produce region highlighting prob…

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -247,8 +247,8 @@ names to which it refers are bound."
       (flycheck-color-mode-line-success-face (:foreground ,green))
 
       ;; Flymake
-      (flymake-warnline (:underline (:style wave :color ,orange) :background ,background))
-      (flymake-errline (:underline (:style wave :color ,red) :background ,background))
+      (flymake-warnline (:underline (:style wave :color ,orange)))
+      (flymake-errline (:underline (:style wave :color ,red)))
       (flymake-error (:underline (:style wave :color ,red)))
       (flymake-note (:underline (:style wave :color ,aqua)))
       (flymake-warning (:underline (:style wave :color ,orange)))


### PR DESCRIPTION
In some cases flymake-warnline and errline applied after region highlight face which would produce holes at selection highlight.
Because of I'm proposing to remove those attributes, but I don't know which cases may be affected. 
[see right side of this screenshot](https://www.dropbox.com/s/9ab35jr3snome6r/Screen%20Shot%202017-12-01%20at%2010.24.51.png?dl=0)