### PR TITLE
Add helm-visible-mark

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -678,6 +678,7 @@ names to which it refers are bound."
       (helm-selection (:inherit highlight))
       (helm-separator (:foreground ,purple))
       (helm-source-header (:weight bold :foreground ,orange :height 1.44))
+      (helm-visible-mark (:foreground ,blue))
 
       ;; company
       (company-preview (:foreground ,comment :background ,contrast-bg))


### PR DESCRIPTION
helm-visible-mark uses green blackground by default, it doesn't look very well with sanityinc-tomorrow-eighties.