### PR TITLE
Make anzu-replace-highlight inherit lazy-highlight

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -320,7 +320,7 @@ names to which it refers are bound."
       ;; Anzu
       (anzu-mode-line (:foreground ,orange))
       (anzu-mode-line-no-match (:foreground ,red))
-      (anzu-replace-highlight (:inherit isearch-lazy-highlight-face))
+      (anzu-replace-highlight (:inherit lazy-highlight))
       (anzu-replace-to (:inherit isearch))
       (anzu-match-1 (:foreground ,yellow ))
       (anzu-match-2 (:foreground ,orange))


### PR DESCRIPTION
`isearch-lazy-highlight-face` has been removed, and elsewhere in the theme it's already been [replaced with `lazy-highlight`](https://github.com/purcell/color-theme-sanityinc-tomorrow/commit/c42554ce5dbc7a7660ee0a8f47861c06634b9b61); this fixes one spot where `anzu-replace-highlight` was inheriting from the old, now-nonexistent face.