### PR TITLE
Add global variable that allows checking what the last set theme was.

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -130,6 +130,9 @@ executed."
                (blue . "#7aa6da")
                (purple . "#c397d8")))))
 
+(defvar color-theme-sanityinc-tomorrow-current nil
+  "Variable to determine what the name of the last set theme was.")
+
 
 
 (defmacro color-theme-sanityinc-tomorrow--with-colors (mode &rest body)
@@ -1306,12 +1309,14 @@ are bound."
 (defun color-theme-sanityinc-tomorrow (mode)
   "Apply the tomorrow variant theme."
   (if (fboundp 'load-theme)
-      (let ((name (color-theme-sanityinc-tomorrow--theme-name mode)))
-        (if (boundp 'custom-enabled-themes)
-            (custom-set-variables `(custom-enabled-themes '(,name)))
-          (if (> emacs-major-version 23)
-              (load-theme name t)
-            (load-theme name))))
+      (progn
+        (setq color-theme-sanityinc-tomorrow-current mode)
+        (let ((name (color-theme-sanityinc-tomorrow--theme-name mode)))
+          (if (boundp 'custom-enabled-themes)
+              (custom-set-variables `(custom-enabled-themes '(,name)))
+            (if (> emacs-major-version 23)
+                (load-theme name t)
+              (load-theme name)))))
     (progn
       (require 'color-theme)
       (color-theme-sanityinc-tomorrow--with-colors


### PR DESCRIPTION
I'm making a function that allows me to toggle between two themes.  After checking the source and issues, there didn't seem to be an easy way to check what the current state was.  I added a variable to allow this behavior.