### PR TITLE
Add basic support for web-mode

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -1222,6 +1222,13 @@ names to which it refers are bound."
       (vr/group-1 (:foreground ,green :background ,background :inverse-video t))
       (vr/group-2 (:foreground ,orange :background ,background :inverse-video t))
 
+      ;; web-mode
+      (web-mode-doctype-face (:inherit font-lock-string-face))
+      (web-mode-html-attr-equal-face (:foreground nil :background nil :inherit default))
+      (web-mode-html-attr-name-face (:inherit font-lock-variable-name-face))
+      (web-mode-html-tag-face (:inherit font-lock-function-name-face))
+      (web-mode-symbol-face (:inherit font-lock-constant-face))
+
       ;; weechat
       (weechat-highlight-face (:foreground ,orange))
       (weechat-nick-self-face (:foreground ,green))


### PR DESCRIPTION
This commit adds basic support for [web-mode](http://web-mode.org/). Admittedly, web-mode is huge and there are many other faces to customize for perfect web-mode support, but for HTML files web-mode now should look similar to the builtin html-mode or mhtml-mode.

Before:
![2018-10-24-120218_1920x1080_scrot](https://user-images.githubusercontent.com/17241079/47444794-48fd9280-d785-11e8-8c24-1f4f0038b5d0.png)

After:
![2018-10-24-120253_1920x1080_scrot](https://user-images.githubusercontent.com/17241079/47444821-57e44500-d785-11e8-9286-cac08fd11216.png)

Thanks!