### PR TITLE
Theme outline-minor-faces

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -526,6 +526,10 @@ names to which it refers are bound."
       (outline-8 (:inherit nil :foreground ,aqua))
       (outline-9 (:inherit nil :foreground ,yellow))
 
+      ;; outline-minor-faces
+      (outline-minor-0 (:weight bold :background ,low-contrast-bg))
+      (outline-minor-1 (:inherit (outline-minor-0 outline-1)))
+
       ;; Parenthesis matching (built-in)
       (show-paren-match (:background ,purple :foreground ,background))
       (show-paren-mismatch (:background ,red :foreground ,background))


### PR DESCRIPTION
This how it looks before my patch:

![before](https://user-images.githubusercontent.com/8199224/50372993-71b0d580-05d8-11e9-917e-9f107a4c1471.png)

And this is after:

![after](https://user-images.githubusercontent.com/8199224/50372995-77a6b680-05d8-11e9-9fcb-31439337c2b6.png)

Nothing really major. :)
