### PR TITLE
Theme stripe-buffer

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -1226,6 +1226,9 @@ names to which it refers are bound."
       (sp-show-pair-match-face (:foreground nil :background nil :inherit show-paren-match))
       (sp-show-pair-mismatch-face (:foreground nil :background nil :inherit show-paren-mismatch))
 
+      ;; stripe-buffer
+      (stripe-highlight (:inherit highlight))
+
       ;; symbol-overlay
       (symbol-overlay-default-face (:inherit highlight :underline t))
 


### PR DESCRIPTION
Support for [stripe-buffer](https://github.com/sabof/stripe-buffer).

Without this PR it looks like this:
![1](https://user-images.githubusercontent.com/8199224/54337980-d9534b80-4630-11e9-820e-756b0599e1df.png)

With this PR it looks like this:
![2](https://user-images.githubusercontent.com/8199224/54337987-deb09600-4630-11e9-8316-4dcd949e06bc.png)
