### PR TITLE
Changed Sly faces from foreground to underline

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -1231,9 +1231,9 @@ names to which it refers are bound."
       ;; SLY
       (sly-error-face (:underline (:color ,red)))
       (sly-mrepl-output-face (:foreground ,purple :background ,background))
-      (sly-note-face (:foreground ,green))
-      (sly-style-warning-face (:foreground ,yellow))
-      (sly-warning-face (:foreground ,orange))
+      (sly-note-face (:underline (:color ,green)))
+      (sly-style-warning-face (:underline (color: ,yellow)))
+      (sly-warning-face (:underline (color: ,orange)))
       (sly-stickers-armed-face (:foreground ,background :background ,blue))
       (sly-stickers-empty-face (:foreground ,background :background ,comment))
       (sly-stickers-placed-face (:foreground ,background :background ,foreground))


### PR DESCRIPTION
Changed Sly's faces for notes, style-warnings and warnings from *foreground* to *underline*.

Hi,

I know it can be very subjective and don't know if subtle was the desired effect, but I've found out that using foreground in Sly's faces for notes, style-warnings and warnings makes them not stand out, in particular notes.

In my opinion using underline isn't too much "garish" but feel free to reject this PR if you don't like the result.

Andrea