### PR TITLE
get it working with emacs22

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ this to your packages list:
 Otherwise, ensure a directory containing these files is on your `load-path`.
 
 If you're using an Emacs version older than 23.x, you'll also need to
-install `color-theme.el`.
+install `color-theme.el` and `color.el`.
 
 ## Usage ##
 

--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -53,8 +53,8 @@
 (require 'color)
 
 (eval-when-compile (require 'ansi-color))
-(when (fboundp 'declare-function)
-  (declare-function color-theme-install "color-theme"))
+(cond ((fboundp 'declare-function)
+       (declare-function color-theme-install "color-theme")))
 
 (defun sanityinc-tomorrow--interpolate (hex1 hex2 gradations which)
   (let ((c1 (color-name-to-rgb hex1))

--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -41,6 +41,8 @@
 ;;     M-x color-theme-sanityinc-tomorrow-bright
 ;;     M-x color-theme-sanityinc-tomorrow-eighties
 ;;
+;; Note that older Emacs will also require color-theme.el and color.el
+;;
 ;;; Credit:
 
 ;; Colour selection by Chris Kempson:
@@ -51,6 +53,9 @@
 (require 'color)
 
 (eval-when-compile (require 'ansi-color))
+(unless (fboundp 'declare-function)
+  (defmacro declare-function (_fn _file &optional _arglist _fileonly)
+    nil))
 (declare-function color-theme-install "color-theme")
 
 (defun sanityinc-tomorrow--interpolate (hex1 hex2 gradations which)

--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -53,10 +53,8 @@
 (require 'color)
 
 (eval-when-compile (require 'ansi-color))
-(unless (fboundp 'declare-function)
-  (defmacro declare-function (_fn _file &optional _arglist _fileonly)
-    nil))
-(declare-function color-theme-install "color-theme")
+(when (fboundp 'declare-function)
+  (declare-function color-theme-install "color-theme"))
 
 (defun sanityinc-tomorrow--interpolate (hex1 hex2 gradations which)
   (let ((c1 (color-name-to-rgb hex1))


### PR DESCRIPTION
Emacs 22.1.1 is the included default on macOS

 - add a stub for `declare-function`
 - mention requiring `color.el`