### PR TITLE
Theme syslog-mode

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -1291,6 +1291,14 @@ names to which it refers are bound."
       ;; symbol-overlay
       (symbol-overlay-default-face (:inherit highlight :underline t))
 
+      ;; syslog-mode
+      (syslog-debug (:weight bold :foreground ,green))
+      (syslog-error (:weight bold :foreground ,red))
+      (syslog-hide (:foregound ,comment))
+      (syslog-info (:weight bold :foreground ,blue))
+      (syslog-su (:weight bold :foreground ,purple))
+      (syslog-warn (:weight bold :foreground ,orange))
+
       ;; transient
       (transient-enabled-suffix (:foreground ,low-contrast-bg :background ,green :weight bold))
       (transient-disabled-suffix (:foreground ,foreground :background ,red :weight bold))


### PR DESCRIPTION
I added support for https://github.com/vapniks/syslog-mode

An example:

![Screenshot from 2019-09-26 12-49-47](https://user-images.githubusercontent.com/8199224/65682943-589fee00-e05c-11e9-95f1-8f45672f2b73.png)
