### PR TITLE
Fix coloring of HTML tag brackets in web-mode

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -1471,6 +1471,7 @@ names to which it refers are bound."
       (web-mode-html-attr-equal-face (:foreground nil :background nil :inherit default))
       (web-mode-html-attr-name-face (:inherit font-lock-variable-name-face))
       (web-mode-html-tag-face (:inherit font-lock-function-name-face))
+      (web-mode-html-tag-bracket-face (:inherit font-lock-function-name-face))
       (web-mode-symbol-face (:inherit font-lock-constant-face))
 
       ;; weechat


### PR DESCRIPTION
Apparently in `web-mode` there is a face `web-mode-html-tag-bracket-face` for the coloring of tag brackets. Without setting it, the brackets by default will have the same color as the background, making them invisible. Adding this line fixes the issue.

Also see a similar issue in https://github.com/oneKelvinSmith/monokai-emacs/issues/102 which had the same fix.