### PR TITLE
Add `dired-mark` face.

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -311,6 +311,9 @@ names to which it refers are bound."
       (diff-refine-changed (:foreground ,yellow))
       (diff-refine-removed (:foreground ,red))
 
+      ;; dired (built-in)
+      (dired-marked (:background ,contrast-bg))
+
       ;; ediff (built-in)
       (ediff-current-diff-A (:foreground ,comment :background ,highlight :extend t))
       (ediff-current-diff-Ancestor (:foreground ,aqua :background ,highlight))


### PR DESCRIPTION
Default `dired-mark` face is inherited from `error`, which color is orange, the same as `dired-directory` which is inherited from `font-lock-function-name-face`.

https://github.com/purcell/color-theme-sanityinc-tomorrow/blob/96dbaa43ff1326879e76a7943b8ae27265ae84e8/color-theme-sanityinc-tomorrow.el#L186

https://github.com/purcell/color-theme-sanityinc-tomorrow/blob/96dbaa43ff1326879e76a7943b8ae27265ae84e8/color-theme-sanityinc-tomorrow.el#L200

It's hard for me to distinguish whether I had marked or not, so I add a face to it. I noticed there is a selection face, so I use it here.

---

Before: 

<img width="712" alt="Snipaste_2022-11-06_10-23-49" src="https://user-images.githubusercontent.com/25452934/200151185-16ed0d0f-2178-418f-98f4-b3047b041cb3.png">

After:

![image](https://user-images.githubusercontent.com/25452934/200151214-ae77e4d7-f36a-4887-a7eb-9cc42a894f5d.png)
