### PR TITLE
Face `line-number` should inherit from default

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -219,7 +219,7 @@ names to which it refers are bound."
       (cursor (:background ,red))
       (fringe (:background ,low-contrast-bg :foreground ,comment))
       (linum (:background ,low-contrast-bg :foreground ,comment :italic nil :underline nil))
-      (line-number (:background ,low-contrast-bg :foreground ,comment))
+      (line-number (:inherit default :background ,low-contrast-bg :foreground ,comment))
       (line-number-current-line (:inherit line-number :foreground ,foreground :weight bold))
       (fill-column-indicator (:foreground ,contrast-bg :weight normal :slant normal
                                           :underline nil :overline nil :strike-through nil


### PR DESCRIPTION
Otherwise, [the font size for `display-line-numbers-mode` does not change with text scale](https://emacs.stackexchange.com/questions/74507/constant-font-size-in-display-line-numbers-mode-when-zooming-in-and-out).

text scale is when you do `M-x text-scale-adjust (C-x C-0)`, `C-<wheel-up/down>` or `<pinch>`.

<details>
<summary>Extra information</summary>
My Emacs version: GNU Emacs 29.2 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.40, cairo version 1.18.0)
</details>
