### PR TITLE
fix(diff-hl): Swap faces colors to properly show diff marks

### DIFF
--- a/color-theme-sanityinc-tomorrow.el
+++ b/color-theme-sanityinc-tomorrow.el
@@ -933,9 +933,9 @@ names to which it refers are bound."
       (define-it-var-face (:foreground ,orange :bold t))
 
       ;; diff-hl
-      (diff-hl-insert (:foreground ,background :background ,green))
-      (diff-hl-change (:foreground ,background :background ,blue))
-      (diff-hl-delete (:foreground ,background :background ,red))
+      (diff-hl-insert (:foreground ,green :background ,background))
+      (diff-hl-change (:foreground ,blue :background ,background))
+      (diff-hl-delete (:foreground ,red :background ,background))
 
       ;; dired
       (dired-marked (:foreground ,green))


### PR DESCRIPTION
The `:foreground` and `:background` values are swapped for how fringe
rendering seems to work.

When the `sanityinc-tomorrow-blue` theme is active any git modifications to
the file using diff-hl are not visible, the reason is that the theme sets
:foreground to the theme's background color (dark blue #002451 for
tomorrow-blue) and :background to the semantic color (green/red/blue).

The hypothesis on why this fails is that diff-hl renders indicators in the
fringe using bitmaps. Fringe bitmaps are drawn using the face's foreground
color, not the background. So the indicators are being drawn in dark
blue (#002451) against a dark fringe — essentially invisible.

This issue was observed in `sanityinc-tomorrow-blue`, other themes in the
collection may or may not be affected by this. However I tested that after
these changes other themes show diff colors just fine.

---

This is a block of code that was added, but there's no indication on the fringe:

<img width="994" height="392" alt="Screenshot from 2026-01-18 17-30-24" src="https://github.com/user-attachments/assets/76b3ec76-b78d-42c7-b884-82b2471434d3" />

After these changes, I can see the addition marks in the fringe:

<img width="994" height="392" alt="Screenshot from 2026-01-18 17-33-41" src="https://github.com/user-attachments/assets/46cf61f3-26c5-4c8c-bf00-677ba8549e35" />

---

How other themes look after these changes:

<img width="994" height="392" alt="Screenshot from 2026-01-18 17-59-58" src="https://github.com/user-attachments/assets/02a29341-971b-4991-8195-e563772ac995" />

<img width="994" height="392" alt="Screenshot from 2026-01-18 18-00-14" src="https://github.com/user-attachments/assets/49d1691e-4575-4617-a446-4df2fb390e0c" />

<img width="994" height="392" alt="Screenshot from 2026-01-18 18-00-28" src="https://github.com/user-attachments/assets/a279f896-bf85-41fc-b974-de7e6a554269" />

<img width="994" height="392" alt="Screenshot from 2026-01-18 18-00-42" src="https://github.com/user-attachments/assets/58d02df7-f9c2-4cee-a1d9-c7210ffa9121" />

<img width="994" height="392" alt="Screenshot from 2026-01-18 18-00-58" src="https://github.com/user-attachments/assets/4faee287-32e3-415a-b447-8b4117e64394" />

















